### PR TITLE
Add proper styling for GitHub Pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title | default: site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="markdown-body">
+        {{ content }}
+      </div>
+    </div>
+  </body>
+</html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,100 +1,136 @@
-
 ---
 ---
 
 @import "{{ site.theme }}";
 
-// Basic styles for the documentation
-.markdown-body {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
+// Base styles
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  line-height: 1.6;
 }
 
-// Expandable sections styling
+// Content container
+.wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+// Markdown content
+.markdown-body {
+  h1, h2, h3 {
+    border-bottom: 1px solid #eaecef;
+    padding-bottom: 0.3em;
+    margin-top: 24px;
+    margin-bottom: 16px;
+  }
+}
+
+// Expandable sections
 .expandable-section {
-  margin: 1em 0;
-  padding: 1em;
+  background-color: #f8f9fa;
   border: 1px solid #e1e4e8;
   border-radius: 6px;
-  background-color: #f6f8fa;
+  margin: 1rem 0;
+  padding: 1rem;
 
   summary {
     cursor: pointer;
     font-weight: 500;
-    margin: -1em;
-    padding: 1em;
-    outline: none;
+    margin: -1rem;
+    padding: 1rem;
 
     &:hover {
-      background-color: #f0f3f6;
+      background-color: #f1f2f3;
     }
   }
 
   &[open] summary {
     border-bottom: 1px solid #e1e4e8;
-    margin-bottom: 1em;
+    margin-bottom: 1rem;
   }
 }
 
-// Table styling
+// Tables
 table {
-  border-collapse: collapse;
+  display: table;
   width: 100%;
-  margin: 1em 0;
+  margin: 1rem 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  overflow: auto;
 
   th, td {
-    padding: 8px 12px;
+    padding: 8px 13px;
     border: 1px solid #e1e4e8;
-    text-align: left;
   }
 
   th {
-    background-color: #f6f8fa;
     font-weight: 600;
+    background-color: #f6f8fa;
   }
 
-  tr:nth-child(even) {
+  tr:nth-child(2n) {
     background-color: #f8f9fa;
   }
 }
 
-// Code block styling
+// Code blocks
 .highlight {
-  margin: 1em 0;
-  padding: 16px;
-  background-color: #f6f8fa;
-  border-radius: 6px;
+  margin: 1rem 0;
 
   pre {
-    margin: 0;
-    overflow-x: auto;
-  }
-}
-
-// Properties section
-.properties-table {
-  code {
-    background-color: #f0f3f6;
-    padding: 2px 6px;
-    border-radius: 3px;
+    padding: 16px;
+    overflow: auto;
     font-size: 85%;
+    line-height: 1.45;
+    background-color: #f6f8fa;
+    border-radius: 6px;
   }
 }
 
-// Navigation and header styling
-.header {
-  margin-bottom: 2em;
-  padding-bottom: 1em;
-  border-bottom: 1px solid #e1e4e8;
-}
-
-// File links styling
-.file-link {
+// Links
+a {
   color: #0366d6;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: underline;
   }
+}
+
+// Details summary
+details summary {
+  outline: none;
+}
+
+// Property section specific
+.properties-section {
+  margin: 2rem 0;
+
+  table {
+    td:first-child {
+      width: 30%;
+      white-space: nowrap;
+    }
+
+    code {
+      background-color: #f6f8fa;
+      padding: 0.2em 0.4em;
+      border-radius: 3px;
+      font-size: 85%;
+      font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    }
+  }
+}
+
+// File links
+.file-link {
+  display: inline-block;
+  padding: 0.2em 0.4em;
+  margin: 0.1em 0;
+  background-color: #f6f8fa;
+  border-radius: 3px;
+  font-size: 85%;
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
 }


### PR DESCRIPTION
This PR adds proper styling for the GitHub Pages documentation. It includes:

1. A custom `style.scss` file in the `assets/css` directory that provides:
   - Better table formatting
   - Proper expandable sections styling
   - Code block improvements
   - Better typography and spacing
   - Responsive layout improvements

2. A custom `default.html` layout that properly includes the styles

The changes will fix the current formatting issues with tables and expandable sections while maintaining a clean, professional look that matches GitHub's documentation style.